### PR TITLE
Patch getHref to also cover non-http(s) protocols

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -317,6 +317,7 @@ An important concept to understand is where links open, whether it's a react nav
 - `/`: plain paths will navigate within React
 - `/?abc=def`: queries, hashtags, etc. will also perform a navigation in React
 - `https://example.com/`: full URLs will trigger a browser page change
+- `tel:+1234567890`, `mailto:test@example.com`: non-HTTP protocol links will trigger a browser action (call, email, etc.)
 - `target="_self"`: will trigger a browser page change, in the same tab
 - `target="_blank"`: will open a new tab
 

--- a/src/helpers/getHref.js
+++ b/src/helpers/getHref.js
@@ -8,11 +8,15 @@ export default el => {
   // Links without href should be ignored
   if (!href) return null;
 
-  // Absolute paths should be ignored
-  if (/^https?:\/\//.test(href)) return null;
+  // Remove leading/trailing whitespace for proper matching
+  const trimmed_href = href.trim();
+
+  // Exclude any href starting with a protocol
+  // This covers: http:, https:, tel:, mailto:, ftp:, file:, data:, javascript:, etc.
+  if (/^[a-zA-Z][a-zA-Z0-9+\-.]*:/.test(trimmed_href)) return null;
 
   // Open it either on a new or same tab, but always with a hard refresh
   if (el.getAttribute("target") !== null) return null;
 
-  return href;
+  return trimmed_href;
 };


### PR DESCRIPTION
## ISSUE
When inserting a link with a non-http(s) protocol, crossroad tries to handle the redirection even though it is not prepared to, showing a blank page and throwing the following error:
`Failed to execute 'pushState' on 'History': A history state object with URL 'mailto:test@example.com' cannot be created in a document with origin 'https://localhost:3007' and URL 'https://localhost:3007/example'.`

## FIX
Patch getHref function to detect links starting with any protocol and let the browser handle them.